### PR TITLE
Add Clang format and reformat ADC files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle:  Google
+DerivePointerAlignment: false
+IndentWidth: 4

--- a/scm_v3c/adc.c
+++ b/scm_v3c/adc.c
@@ -83,36 +83,56 @@ static void adc_set_settling_time_asc_bits(uint8_t settling_time) {
     adc_set_asc_bit(ADC_SETTLING_TIME_7_ASC_BIT, settling_time & 0x1);
 }
 
-static void adc_set_bandgap_refernce_tuning_code_asc_bits(uint8_t bandgap_reference_tuning_code) {
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_0_ASC_BIT, (bandgap_reference_tuning_code >> 6) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_1_ASC_BIT, (bandgap_reference_tuning_code >> 5) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_2_ASC_BIT, (bandgap_reference_tuning_code >> 4) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_3_ASC_BIT, (bandgap_reference_tuning_code >> 3) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_4_ASC_BIT, (bandgap_reference_tuning_code >> 2) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_5_ASC_BIT, (bandgap_reference_tuning_code >> 1) & 0x1);
-    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_6_ASC_BIT, bandgap_reference_tuning_code & 0x1);
+static void adc_set_bandgap_refernce_tuning_code_asc_bits(
+    uint8_t bandgap_reference_tuning_code) {
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_0_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 6) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_1_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 5) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_2_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 4) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_3_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 3) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_4_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 2) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_5_ASC_BIT,
+                    (bandgap_reference_tuning_code >> 1) & 0x1);
+    adc_set_asc_bit(ADC_BANDGAP_REFERENCE_TUNING_CODE_6_ASC_BIT,
+                    bandgap_reference_tuning_code & 0x1);
 }
 
-static void adc_set_const_gm_tuning_code_asc_bits(uint8_t const_gm_tuning_code) {
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_0_ASC_BIT, (const_gm_tuning_code >> 7) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_1_ASC_BIT, (const_gm_tuning_code >> 6) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_2_ASC_BIT, (const_gm_tuning_code >> 5) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_3_ASC_BIT, (const_gm_tuning_code >> 4) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_4_ASC_BIT, (const_gm_tuning_code >> 3) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_5_ASC_BIT, (const_gm_tuning_code >> 2) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_6_ASC_BIT, (const_gm_tuning_code >> 1) & 0x1);
-    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_7_ASC_BIT, const_gm_tuning_code & 0x1);
+static void adc_set_const_gm_tuning_code_asc_bits(
+    uint8_t const_gm_tuning_code) {
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_0_ASC_BIT,
+                    (const_gm_tuning_code >> 7) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_1_ASC_BIT,
+                    (const_gm_tuning_code >> 6) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_2_ASC_BIT,
+                    (const_gm_tuning_code >> 5) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_3_ASC_BIT,
+                    (const_gm_tuning_code >> 4) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_4_ASC_BIT,
+                    (const_gm_tuning_code >> 3) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_5_ASC_BIT,
+                    (const_gm_tuning_code >> 2) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_6_ASC_BIT,
+                    (const_gm_tuning_code >> 1) & 0x1);
+    adc_set_asc_bit(ADC_CONST_GM_DEVICE_TUNING_CODE_7_ASC_BIT,
+                    const_gm_tuning_code & 0x1);
 }
 
-void adc_config(adc_config_t* adc_config) {
+void adc_config(const adc_config_t* adc_config) {
     // Set the ASC bit for the ADC reset signal source.
-    adc_set_asc_bit(ADC_RESET_SOURCE_ASC_BIT, (uint8_t)adc_config->reset_source);
+    adc_set_asc_bit(ADC_RESET_SOURCE_ASC_BIT,
+                    (uint8_t)adc_config->reset_source);
 
     // Set the ASC bit for the ADC convert signal source.
-    adc_set_asc_bit(ADC_CONVERT_SOURCE_ASC_BIT, (uint8_t)adc_config->convert_source);
+    adc_set_asc_bit(ADC_CONVERT_SOURCE_ASC_BIT,
+                    (uint8_t)adc_config->convert_source);
 
     // Set the ASC bit for the PGA amplify signal source.
-    adc_set_asc_bit(ADC_PGA_AMPLIFY_SOURCE_ASC_BIT, (uint8_t)adc_config->pga_amplify_source);
+    adc_set_asc_bit(ADC_PGA_AMPLIFY_SOURCE_ASC_BIT,
+                    (uint8_t)adc_config->pga_amplify_source);
 
     // Set the ASC bits for the PGA gain.
     adc_set_pga_gain_asc_bits(adc_config->pga_gain);
@@ -121,20 +141,24 @@ void adc_config(adc_config_t* adc_config) {
     adc_set_settling_time_asc_bits(adc_config->settling_time);
 
     // Set the ASC bits for the bandgap reference tuning code.
-    adc_set_bandgap_refernce_tuning_code_asc_bits(adc_config->bandgap_reference_tuning_code);
+    adc_set_bandgap_refernce_tuning_code_asc_bits(
+        adc_config->bandgap_reference_tuning_code);
 
     // Set the ASC bits for the const gm device tuning code.
     adc_set_const_gm_tuning_code_asc_bits(adc_config->const_gm_tuning_code);
 
     // Set the ASC bit for enabling the VBAT / 4 input.
-    adc_set_asc_bit(ADC_VBAT_DIV_4_ENABLED_ASC_BIT, adc_config->vbat_div_4_enabled);
+    adc_set_asc_bit(ADC_VBAT_DIV_4_ENABLED_ASC_BIT,
+                    adc_config->vbat_div_4_enabled);
 
     // Set the ASC bit for enabling the on-chip LDO.
     adc_set_asc_bit(ADC_LDO_ENABLED_ASC_BIT, adc_config->ldo_enabled);
 
     // Set the ASC bits for the ADC input mux select.
-    adc_set_asc_bit(ADC_INPUT_MUX_SELECT_0_ASC_BIT, (adc_config->input_mux_select >> 1) & 0x1);
-    adc_set_asc_bit(ADC_INPUT_MUX_SELECT_1_ASC_BIT, adc_config->input_mux_select & 0x1);
+    adc_set_asc_bit(ADC_INPUT_MUX_SELECT_0_ASC_BIT,
+                    (adc_config->input_mux_select >> 1) & 0x1);
+    adc_set_asc_bit(ADC_INPUT_MUX_SELECT_1_ASC_BIT,
+                    adc_config->input_mux_select & 0x1);
 
     // Set the ASC bit for bypassing the PGA.
     adc_set_asc_bit(ADC_PGA_BYPASS_ASC_BIT, adc_config->pga_bypass);

--- a/scm_v3c/adc.h
+++ b/scm_v3c/adc.h
@@ -4,10 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-//=========================== define ==========================================
-
-//=========================== typedef =========================================
-
 // ADC reset signal source enum.
 typedef enum {
     ADC_RESET_SOURCE_INVALID = -1,
@@ -49,24 +45,28 @@ typedef struct {
     // PGA amplify signal source.
     adc_pga_amplify_source_t pga_amplify_source;
 
-    // 8-bit PGA gain. The actual gain is pga_gain + 1 for a range from 1 to 256.
+    // 8-bit PGA gain. The actual gain is pga_gain + 1 for a range from 1 to
+    // 256.
     uint8_t pga_gain;
 
-    // 8-bit ADC settling time. 0x00 gives the ADC roughly 1.72 us to retrieve all 10 bits,
-    // and 0xFF gives the ADC roughly 0.35 us to retrieve all 10 bits.
+    // 8-bit ADC settling time. 0x00 gives the ADC roughly 1.72 us to retrieve
+    // all 10 bits, and 0xFF gives the ADC roughly 0.35 us to retrieve all 10
+    // bits.
     uint8_t settling_time;
 
-    // 7-bit bandgap reference tuning code to control the reference voltage to the LDO.
-    // The MSB is the panic bit and sets the reference voltage to the maximum, which is
-    // around 1.2 V. 0x00 sets the reference voltage to the minimum, which is around 0.8 V.
+    // 7-bit bandgap reference tuning code to control the reference voltage to
+    // the LDO. The MSB is the panic bit and sets the reference voltage to the
+    // maximum, which is around 1.2 V. 0x00 sets the reference voltage to the
+    // minimum, which is around 0.8 V.
     uint8_t bandgap_reference_tuning_code;
 
-    // 8-bit const gm device tuning code to control the reference current used in the ADC's
-    // comparator and the PGA. Increasing the tuning code decreases the reference current.
+    // 8-bit const gm device tuning code to control the reference current used
+    // in the ADC's comparator and the PGA. Increasing the tuning code decreases
+    // the reference current.
     uint8_t const_gm_tuning_code;
 
-    // If true, the VBAT / 4 input to the mux is enabled. Note that this not choose VBAT / 4
-    // as the output of the mux.
+    // If true, the VBAT / 4 input to the mux is enabled. Note that this does
+    // not choose VBAT / 4 as the output of the mux.
     bool vbat_div_4_enabled;
 
     // If true, the on-chip LDO is enabled.
@@ -88,15 +88,11 @@ typedef struct {
     uint16_t data;
 } adc_output_t;
 
-//=========================== variables =======================================
-
 // ADC output.
 extern adc_output_t g_adc_output;
 
-//=========================== prototypes ======================================
-
 // Configure the ADC according to the given ADC config.
-void adc_config(adc_config_t* adc_config);
+void adc_config(const adc_config_t* adc_config);
 
 // Trigger an ADC read.
 void adc_trigger(void);

--- a/scm_v3c/applications/scumstar/scumstar.uvprojx
+++ b/scm_v3c/applications/scumstar/scumstar.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>ARMCM0</Device>
           <Vendor>ARM</Vendor>
-          <PackID>ARM.CMSIS.5.7.0</PackID>
+          <PackID>ARM.CMSIS.5.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IROM(0x00000000,0x80000) IRAM(0x20000000,0x20000) CPUTYPE("Cortex-M0") CLOCK(10000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -184,8 +184,6 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>0</RvdsVP>
-            <RvdsMve>0</RvdsMve>
-            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -352,7 +350,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
             <useXO>0</useXO>
-            <ClangAsOpt>1</ClangAsOpt>
+            <uClangAs>0</uClangAs>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -507,7 +505,7 @@
         <TargetCommonOption>
           <Device>ARMCM0</Device>
           <Vendor>ARM</Vendor>
-          <PackID>ARM.CMSIS.5.7.0</PackID>
+          <PackID>ARM.CMSIS.5.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IROM(0x00000000,0x80000) IRAM(0x20000000,0x20000) CPUTYPE("Cortex-M0") CLOCK(10000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -675,8 +673,6 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>0</RvdsVP>
-            <RvdsMve>0</RvdsMve>
-            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -843,7 +839,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
             <useXO>0</useXO>
-            <ClangAsOpt>1</ClangAsOpt>
+            <uClangAs>0</uClangAs>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>

--- a/scm_v3c/applications/sensor_adc/sensor_adc.c
+++ b/scm_v3c/applications/sensor_adc/sensor_adc.c
@@ -3,44 +3,31 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "scm3c_hw_interface.h"
+#include "adc.h"
 #include "memory_map.h"
 #include "optical.h"
-#include "adc.h"
+#include "scm3c_hw_interface.h"
 
-//=========================== defines =========================================
-
-//=========================== variables =======================================
-
-typedef struct {
-    adc_config_t adc_config;
-} app_vars_t;
-
-app_vars_t app_vars;
-
-//=========================== prototypes ======================================
-
-//=========================== main ============================================
+static const adc_config_t g_adc_config = {
+    .reset_source = ADC_RESET_SOURCE_FSM,
+    .convert_source = ADC_CONVERT_SOURCE_FSM,
+    .pga_amplify_source = ADC_PGA_AMPLIFY_SOURCE_FSM,
+    .pga_gain = 0,
+    .settling_time = 0,
+    .bandgap_reference_tuning_code = 1,
+    .const_gm_tuning_code = 0xFF,
+    .vbat_div_4_enabled = true,
+    .ldo_enabled = true,
+    .input_mux_select = ADC_INPUT_MUX_SELECT_V_BAT_DIV_4,
+    .pga_bypass = true,
+};
 
 int main(void) {
-    uint32_t i = 0;
-
     initialize_mote();
 
     // Configure the ADC.
-    printf("Configuring the ADC...\n");
-    app_vars.adc_config.reset_source = ADC_RESET_SOURCE_FSM;
-    app_vars.adc_config.convert_source = ADC_CONVERT_SOURCE_FSM;
-    app_vars.adc_config.pga_amplify_source = ADC_PGA_AMPLIFY_SOURCE_FSM;
-    app_vars.adc_config.pga_gain = 0;
-    app_vars.adc_config.settling_time = 0;
-    app_vars.adc_config.bandgap_reference_tuning_code = 1;
-    app_vars.adc_config.const_gm_tuning_code = 0xFF;
-    app_vars.adc_config.vbat_div_4_enabled = true;
-    app_vars.adc_config.ldo_enabled = true;
-    app_vars.adc_config.input_mux_select = ADC_INPUT_MUX_SELECT_V_BAT_DIV_4;
-    app_vars.adc_config.pga_bypass = true;
-    adc_config(&app_vars.adc_config);
+    printf("Configuring the ADC.\n");
+    adc_config(&g_adc_config);
     adc_enable_interrupt();
 
     analog_scan_chain_write();
@@ -53,17 +40,15 @@ int main(void) {
         // Trigger an ADC read.
         printf("Triggering ADC.\n");
         adc_trigger();
-        while (!g_adc_output.valid);
+        while (!g_adc_output.valid) {
+        }
         if (!g_adc_output.valid) {
             printf("ADC output should be valid.\n");
         }
         printf("ADC output: %u\n", g_adc_output.data);
 
         // Wait a bit.
-        for (i = 0; i < 1000000; i++);
+        for (uint32_t i = 0; i < 1000000; ++i) {
+        }
     }
 }
-
-//=========================== public ==========================================
-
-//=========================== private =========================================

--- a/scm_v3c/applications/sensor_adc/sensor_adc.uvprojx
+++ b/scm_v3c/applications/sensor_adc/sensor_adc.uvprojx
@@ -323,7 +323,7 @@
             <wLevel>2</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
-            <uC99>0</uC99>
+            <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>1</v6Lang>


### PR DESCRIPTION
* `.clang_format` contains the customizations for the Clang formatter.  To run the Clang formatter on some files, install `clang-format` and run:
```bash
clang-format -i applications/sensor_adc/*.c
```