### PR TITLE
Frequency sweep fix

### DIFF
--- a/scm_v3c/rftimer.c
+++ b/scm_v3c/rftimer.c
@@ -71,6 +71,7 @@ void rftimer_setCompareIn(uint32_t val) { rftimer_setCompareIn_by_id(val, 0); }
 
 void rftimer_setCompareIn_by_id(uint32_t val, uint8_t id) {
     rftimer_enable_interrupts_by_id(id);
+    rftimer_enable_interrupts();
 
     // A timer scheudled in the past
 
@@ -156,6 +157,7 @@ void delay_milliseconds_asynchronous(unsigned int delay_milli, uint8_t id) {
     unsigned int rf_timer_count =
         delay_milli * 500;  // same as (delay_milli * 500000) / 1000;
     rftimer_enable_interrupts_by_id(id);
+    rftimer_enable_interrupts();
     timer_durations[id] = delay_milli;
 
     rftimer_setCompareIn_by_id(rftimer_readCounter() + rf_timer_count, id);


### PR DESCRIPTION
when the rftimer_enable_interrupts() function was split, the enable wasn't added back in. By adding rftimer_enable_interrupts after reftimer_enable_interrupts_by_id the code should work like it did before #37 change.