### PR TITLE
set/clear_asc_bit fix (#53)

### DIFF
--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1441,6 +1441,9 @@ void set_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
+    
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
@@ -1453,6 +1456,9 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));


### PR DESCRIPTION
Adding a NOP at the end of the set_asc_bit and clear_asc_bit function allows the chip to fully initialize now.