### PR TITLE
1.1 v fix, calibration fix, FIXED mode fix(freq_sweep), additional freq_sweep fixes

### DIFF
--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -95,9 +95,9 @@ void optical_32_isr(void) {
 // to returning from this ISR, or else it will immediately execute again
 void optical_sfd_isr(void) {
     // 1.1V (helps reorder assembly code)
-	  uint32_t dummy = 0;
-	
-	  int32_t t;
+    uint32_t dummy = 0;
+
+    int32_t t;
     uint32_t rdata_lsb, rdata_msb;
     uint32_t count_LC, count_32k, count_2M, count_HFclock, count_IF;
 
@@ -244,11 +244,11 @@ void optical_sfd_isr(void) {
     }
 
     // Debugging output
-    //broken down for 1.1V fix
-    printf("HF=%d-%d   2M=%d-%d", count_HFclock,HF_CLOCK_fine, count_2M,
-            RC2M_coarse);
+    // broken down for 1.1V fix
+    printf("HF=%d-%d   2M=%d-%d", count_HFclock, HF_CLOCK_fine, count_2M,
+           RC2M_coarse);
     printf(",%d,%d   LC=%d-%d   ", RC2M_fine, RC2M_superfine, count_LC,
-            optical_vars.LC_code);
+           optical_vars.LC_code);
     printf("IF=%d-%d\r\n", count_IF, IF_fine);
 
     if (optical_vars.optical_cal_iteration == 25) {

--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -94,7 +94,10 @@ void optical_32_isr(void) {
 // optical data transfer Need to make sure a new bit has been clocked in prior
 // to returning from this ISR, or else it will immediately execute again
 void optical_sfd_isr(void) {
-    int32_t t;
+    // 1.1V (helps reorder assembly code)
+		uint32_t dummy = 0;
+	
+		int32_t t;
     uint32_t rdata_lsb, rdata_msb;
     uint32_t count_LC, count_32k, count_2M, count_HFclock, count_IF;
 

--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -95,9 +95,9 @@ void optical_32_isr(void) {
 // to returning from this ISR, or else it will immediately execute again
 void optical_sfd_isr(void) {
     // 1.1V (helps reorder assembly code)
-		uint32_t dummy = 0;
+	uint32_t dummy = 0;
 	
-		int32_t t;
+	int32_t t;
     uint32_t rdata_lsb, rdata_msb;
     uint32_t count_LC, count_32k, count_2M, count_HFclock, count_IF;
 
@@ -244,9 +244,12 @@ void optical_sfd_isr(void) {
     }
 
     // Debugging output
-    printf("HF=%d-%d   2M=%d-%d,%d,%d   LC=%d-%d   IF=%d-%d\r\n", count_HFclock,
-           HF_CLOCK_fine, count_2M, RC2M_coarse, RC2M_fine, RC2M_superfine,
-           count_LC, optical_vars.LC_code, count_IF, IF_fine);
+    //broken down for 1.1V fix
+    printf("HF=%d-%d   2M=%d-%d", count_HFclock,HF_CLOCK_fine, count_2M,
+            RC2M_coarse);
+    printf(",%d,%d   LC=%d-%d   ", RC2M_fine, RC2M_superfine, count_LC,
+            optical_vars.LC_code);
+    printf("IF=%d-%d\r\n", count_IF, IF_fine);
 
     if (optical_vars.optical_cal_iteration == 25) {
         // Disable this ISR

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -249,12 +249,18 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_start = repeat_rx_tx_params.fixed_lc_mid;
         cfg_fine_start = repeat_rx_tx_params.fixed_lc_fine;
 
+        // 1.1V (NOP)
         cfg_coarse_stop = cfg_coarse_start + 1;
+        __asm("NOP");
         cfg_mid_stop = cfg_mid_start + 1;
+        __asm("NOP");
         cfg_fine_stop = cfg_fine_start + 1;
-
+        
+        //1.1V
+        __asm("NOP");
         printf("Fixed %s at c:%u m:%u f:%u\n", radio_mode_string,
                cfg_coarse_start, cfg_mid_start, cfg_fine_start);
+       
     } else {  // sweep mode
         cfg_coarse_start = repeat_rx_tx_params.sweep_lc_coarse_start;
         cfg_coarse_stop = repeat_rx_tx_params.sweep_lc_coarse_end;
@@ -263,9 +269,9 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_fine_start = repeat_rx_tx_params.sweep_lc_fine_start;
         cfg_fine_stop = repeat_rx_tx_params.sweep_lc_fine_end;
         // 1.1V probably can be added back in if broken down
-				//printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
-        //       radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
-        //       cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
+		//		printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
+        //      radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
+        //      cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
     }
 		// 1.1V
 		__asm("NOP");
@@ -287,23 +293,27 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                                cfg_mid, cfg_fine);
                     }
 
+                    // 1.1V
+                    __asm("NOP");
                     LC_FREQCHANGE(cfg_coarse, cfg_mid, cfg_fine);
 
                     if (repeat_rx_tx_params.radio_mode == RX_MODE) {
                         receive_packet_length(repeat_rx_tx_params.pkt_len,
-                                              true);
+                                true);
                     } else if (repeat_rx_tx_params.radio_mode == TX_MODE) {
                         for (i = 1; i < repeat_rx_tx_params.pkt_len; i++) {
                             repeat_rx_tx_params.txPacket[i] = ' ';
                         }
 
                         // 1.1V
-												txPacket_fix = repeat_rx_tx_params.txPacket;
-												__asm("NOP");
-												// 1.1V
+						txPacket_fix = repeat_rx_tx_params.txPacket;
+					    __asm("NOP");
+						
+                        // 1.1V
                         repeat_rx_tx_params.fill_tx_packet(
                             txPacket_fix, pkt_len_fix, state);
-												// 1.1V
+						
+                        // 1.1V
                         send_packet(txPacket_fix, pkt_len_fix);
                     }
 

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -226,6 +226,10 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
     uint8_t cfg_coarse_stop;
     uint8_t cfg_mid_stop;
     uint8_t cfg_fine_stop;
+		
+		// 1.1V (helps reorder assembly code)
+		uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
+		uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
 
     int pkt_count = 0;
     char* radio_mode_string;
@@ -258,11 +262,14 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_stop = repeat_rx_tx_params.sweep_lc_mid_end;
         cfg_fine_start = repeat_rx_tx_params.sweep_lc_fine_start;
         cfg_fine_stop = repeat_rx_tx_params.sweep_lc_fine_end;
-        printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
-               radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
-               cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
+        // 1.1V probably can be added back in if broken down
+				//printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
+        //       radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
+        //       cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
     }
-
+		// 1.1V
+		__asm("NOP");
+		
     while (1) {
         // loop through all LC configuration
         for (cfg_coarse = cfg_coarse_start; cfg_coarse < cfg_coarse_stop;
@@ -290,12 +297,14 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                             repeat_rx_tx_params.txPacket[i] = ' ';
                         }
 
+                        // 1.1V
+												txPacket_fix = repeat_rx_tx_params.txPacket;
+												__asm("NOP");
+												// 1.1V
                         repeat_rx_tx_params.fill_tx_packet(
-                            repeat_rx_tx_params.txPacket,
-                            repeat_rx_tx_params.pkt_len, state);
-
-                        send_packet(repeat_rx_tx_params.txPacket,
-                                    repeat_rx_tx_params.pkt_len);
+                            txPacket_fix, pkt_len_fix, state);
+												// 1.1V
+                        send_packet(txPacket_fix, pkt_len_fix);
                     }
 
                     pkt_count += 1;

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -227,9 +227,9 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
     uint8_t cfg_mid_stop;
     uint8_t cfg_fine_stop;
 		
-		// 1.1V (helps reorder assembly code)
-		uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
-		uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
+	// 1.1V (helps reorder assembly code)
+	uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
+	uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
 
     int pkt_count = 0;
     char* radio_mode_string;

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -226,10 +226,10 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
     uint8_t cfg_coarse_stop;
     uint8_t cfg_mid_stop;
     uint8_t cfg_fine_stop;
-		
-		// 1.1V (helps reorder assembly code)
-		uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
-		uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
+
+    // 1.1V (helps reorder assembly code)
+    uint8_t* txPacket_fix = repeat_rx_tx_params.txPacket;
+    uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
 
     int pkt_count = 0;
     char* radio_mode_string;
@@ -255,12 +255,12 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_stop = cfg_mid_start + 1;
         __asm("NOP");
         cfg_fine_stop = cfg_fine_start + 1;
-        
-        //1.1V
+
+        // 1.1V
         __asm("NOP");
         printf("Fixed %s at c:%u m:%u f:%u\n", radio_mode_string,
                cfg_coarse_start, cfg_mid_start, cfg_fine_start);
-       
+
     } else {  // sweep mode
         cfg_coarse_start = repeat_rx_tx_params.sweep_lc_coarse_start;
         cfg_coarse_stop = repeat_rx_tx_params.sweep_lc_coarse_end;
@@ -269,14 +269,14 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_fine_start = repeat_rx_tx_params.sweep_lc_fine_start;
         cfg_fine_stop = repeat_rx_tx_params.sweep_lc_fine_end;
         // 1.1V probably can be added back in if broken down
-				//printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
+        // printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
         //       radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
         //       cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
     }
-    
-		// 1.1V
-		__asm("NOP");
-		
+
+    // 1.1V
+    __asm("NOP");
+
     while (1) {
         // loop through all LC configuration
         for (cfg_coarse = cfg_coarse_start; cfg_coarse < cfg_coarse_stop;
@@ -300,20 +300,20 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
 
                     if (repeat_rx_tx_params.radio_mode == RX_MODE) {
                         receive_packet_length(repeat_rx_tx_params.pkt_len,
-                                true);
+                                              true);
                     } else if (repeat_rx_tx_params.radio_mode == TX_MODE) {
                         for (i = 1; i < repeat_rx_tx_params.pkt_len; i++) {
                             repeat_rx_tx_params.txPacket[i] = ' ';
                         }
 
                         // 1.1V
-												txPacket_fix = repeat_rx_tx_params.txPacket;
-												__asm("NOP");
-                        
-												// 1.1V
-                        repeat_rx_tx_params.fill_tx_packet(
-                            txPacket_fix, pkt_len_fix, state);
-												
+                        txPacket_fix = repeat_rx_tx_params.txPacket;
+                        __asm("NOP");
+
+                        // 1.1V
+                        repeat_rx_tx_params.fill_tx_packet(txPacket_fix,
+                                                           pkt_len_fix, state);
+
                         // 1.1V
                         send_packet(txPacket_fix, pkt_len_fix);
                     }

--- a/scm_v3c/retarget.c
+++ b/scm_v3c/retarget.c
@@ -13,10 +13,6 @@ struct __FILE {
 FILE __stdout = {(unsigned char*)APB_UART_BASE};
 FILE __stdin = {(unsigned char*)APB_UART_BASE};
 
-int fputc(int ch, FILE* f) { return (uart_out(ch)); }
-
-int fgetc(FILE* f) { return (uart_in()); }
-
 int ferror(FILE* f) { return 0; }
 
 int uart_out(int ch) {
@@ -34,6 +30,10 @@ int uart_in() {
     uart_out(ch);
     return ((int)ch);
 }
+
+int fputc(int ch, FILE* f) { return (uart_out(ch)); }
+
+int fgetc(FILE* f) { return (uart_in()); }
 
 void _ttywrch(int ch) { fputc(ch, &__stdout); }
 

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,9 +1442,6 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
-    // Needed for no 1.1V -> VDDD fix
-    __asm("NOP");
-
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
 }
@@ -1456,9 +1453,6 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
-
-    // Needed for no 1.1V -> VDDD fix
-    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,6 +1442,9 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
+
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
 }
@@ -1453,6 +1456,9 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1476,9 +1476,13 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     //        none, it programs the LC radio frequency immediately
 
     // mask to ensure that the coarse, mid, and fine are actually 5-bit
+		// 1.1V (NOP)
     char coarse_m = (char)(coarse & 0x1F);
+		__asm("NOP");
     char mid_m = (char)(mid & 0x1F);
-    char fine_m = (char)(fine & 0x1F);
+		__asm("NOP");
+		char fine_m = (char)(fine & 0x1F);
+		__asm("NOP");
 
     // flip the bit order to make it fit more easily into the ACFG registers
     unsigned int coarse_f = (unsigned int)(flipChar(coarse_m));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1441,7 +1441,7 @@ void set_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
-    
+
     // Needed for no 1.1V -> VDDD fix
     __asm("NOP");
 
@@ -1476,13 +1476,13 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     //        none, it programs the LC radio frequency immediately
 
     // mask to ensure that the coarse, mid, and fine are actually 5-bit
-		// 1.1V (NOP)
+    // 1.1V (NOP)
     char coarse_m = (char)(coarse & 0x1F);
-		__asm("NOP");
+    __asm("NOP");
     char mid_m = (char)(mid & 0x1F);
-		__asm("NOP");
-		char fine_m = (char)(fine & 0x1F);
-		__asm("NOP");
+    __asm("NOP");
+    char fine_m = (char)(fine & 0x1F);
+    __asm("NOP");
 
     // flip the bit order to make it fit more easily into the ACFG registers
     // 1.1V (NOP)

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,7 +1442,7 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
-    // Needed for no 1.1V -> VDDD fix
+    // 1.1V FIX (Adds delay before trying to restore registers from stack)
     __asm("NOP");
 
     // Possibly more efficient
@@ -1457,7 +1457,7 @@ void clear_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
 
-    // Needed for no 1.1V -> VDDD fix
+    // 1.1V FIX (Adds delay before trying to restore registers from stack)
     __asm("NOP");
 
     // Possibly more efficient

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1476,18 +1476,22 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     //        none, it programs the LC radio frequency immediately
 
     // mask to ensure that the coarse, mid, and fine are actually 5-bit
-		// 1.1V (NOP)
+	// 1.1V (NOP)
     char coarse_m = (char)(coarse & 0x1F);
-		__asm("NOP");
+	__asm("NOP");
     char mid_m = (char)(mid & 0x1F);
-		__asm("NOP");
-		char fine_m = (char)(fine & 0x1F);
-		__asm("NOP");
+	__asm("NOP");
+	char fine_m = (char)(fine & 0x1F);
+	__asm("NOP");
 
     // flip the bit order to make it fit more easily into the ACFG registers
+    // 1.1V (NOP)
     unsigned int coarse_f = (unsigned int)(flipChar(coarse_m));
+    __asm("NOP");
     unsigned int mid_f = (unsigned int)(flipChar(mid_m));
+    __asm("NOP");
     unsigned int fine_f = (unsigned int)(flipChar(fine_m));
+    __asm("NOP");
 
     // initialize registers
     unsigned int fcode =

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1441,6 +1441,9 @@ void set_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
+    
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
@@ -1453,6 +1456,9 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));


### PR DESCRIPTION
The braking down of the print function in the optical_sfd_isr() function fixes the calibration bug where it prints the wrong values. Still need to fix longer than usual calibration without 1.1V bug. The NOP's in the LC_FREQCHANGE() function fix some the consistency of the frequency sweeping values. Before the fine and mid values of the sweep weren't being used consistently. The NOP's added in the repeat_rx_tx() function fix the FIXED mode for the simple frequency sweep project. The retarget.c functions were re-ordered to remove some warnings. This doesn't change the behavior of the code and has nothing to do with 1.1V fixes. Other changes were formatting fixes. 