### PR TITLE
1.1 v fix changes

### DIFF
--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -94,10 +94,7 @@ void optical_32_isr(void) {
 // optical data transfer Need to make sure a new bit has been clocked in prior
 // to returning from this ISR, or else it will immediately execute again
 void optical_sfd_isr(void) {
-    // 1.1V (helps reorder assembly code)
-		uint32_t dummy = 0;
-	
-		int32_t t;
+    int32_t t;
     uint32_t rdata_lsb, rdata_msb;
     uint32_t count_LC, count_32k, count_2M, count_HFclock, count_IF;
 

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -226,10 +226,6 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
     uint8_t cfg_coarse_stop;
     uint8_t cfg_mid_stop;
     uint8_t cfg_fine_stop;
-		
-		// 1.1V (helps reorder assembly code)
-		uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
-		uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
 
     int pkt_count = 0;
     char* radio_mode_string;
@@ -262,14 +258,11 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_stop = repeat_rx_tx_params.sweep_lc_mid_end;
         cfg_fine_start = repeat_rx_tx_params.sweep_lc_fine_start;
         cfg_fine_stop = repeat_rx_tx_params.sweep_lc_fine_end;
-        // 1.1V probably can be added back in if broken down
-				//printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
-        //       radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
-        //       cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
+        printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
+               radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
+               cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
     }
-		// 1.1V
-		__asm("NOP");
-		
+
     while (1) {
         // loop through all LC configuration
         for (cfg_coarse = cfg_coarse_start; cfg_coarse < cfg_coarse_stop;
@@ -297,14 +290,12 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                             repeat_rx_tx_params.txPacket[i] = ' ';
                         }
 
-                        // 1.1V
-												txPacket_fix = repeat_rx_tx_params.txPacket;
-												__asm("NOP");
-												// 1.1V
                         repeat_rx_tx_params.fill_tx_packet(
-                            txPacket_fix, pkt_len_fix, state);
-												// 1.1V
-                        send_packet(txPacket_fix, pkt_len_fix);
+                            repeat_rx_tx_params.txPacket,
+                            repeat_rx_tx_params.pkt_len, state);
+
+                        send_packet(repeat_rx_tx_params.txPacket,
+                                    repeat_rx_tx_params.pkt_len);
                     }
 
                     pkt_count += 1;

--- a/scm_v3c/retarget.c
+++ b/scm_v3c/retarget.c
@@ -13,6 +13,10 @@ struct __FILE {
 FILE __stdout = {(unsigned char*)APB_UART_BASE};
 FILE __stdin = {(unsigned char*)APB_UART_BASE};
 
+int fputc(int ch, FILE* f) { return (uart_out(ch)); }
+
+int fgetc(FILE* f) { return (uart_in()); }
+
 int ferror(FILE* f) { return 0; }
 
 int uart_out(int ch) {
@@ -30,10 +34,6 @@ int uart_in() {
     uart_out(ch);
     return ((int)ch);
 }
-
-int fputc(int ch, FILE* f) { return (uart_out(ch)); }
-
-int fgetc(FILE* f) { return (uart_in()); }
 
 void _ttywrch(int ch) { fputc(ch, &__stdout); }
 

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,9 +1442,6 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
-    // Needed for no 1.1V -> VDDD fix
-    __asm("NOP");
-
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
 }
@@ -1456,9 +1453,6 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
-
-    // Needed for no 1.1V -> VDDD fix
-    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,6 +1442,10 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
+    // 1.1V FIX (Adds delay before trying to restore registers from stack)
+    // Without NOP, position variable is zero (when it shouldn't be)
+    __asm("NOP");
+
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
 }
@@ -1453,6 +1457,10 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // 1.1V FIX (Adds delay before trying to restore registers from stack)
+    // Without NOP, position variable is zero (when it shouldn't be)
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1442,6 +1442,9 @@ void set_asc_bit(unsigned int position) {
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
 
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
+
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
 }
@@ -1453,6 +1456,9 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1441,7 +1441,7 @@ void set_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
-  
+
     // 1.1V FIX (Adds delay before trying to restore registers from stack)
     // Without NOP, position variable is zero (when it shouldn't be)
     __asm("NOP");
@@ -1457,10 +1457,11 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
-  
+
     // 1.1V FIX (Adds delay before trying to restore registers from stack)
     // Without NOP, position variable is zero (when it shouldn't be)
-  
+    __asm("NOP");
+
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));
 }
@@ -1479,7 +1480,7 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     // mask to ensure that the coarse, mid, and fine are actually 5-bit
     char coarse_m = (char)(coarse & 0x1F);
     char mid_m = (char)(mid & 0x1F);
-		char fine_m = (char)(fine & 0x1F);
+    char fine_m = (char)(fine & 0x1F);
 
     // flip the bit order to make it fit more easily into the ACFG registers
     unsigned int coarse_f = (unsigned int)(flipChar(coarse_m));


### PR DESCRIPTION
This is the first set of broken code when there isn't 1.1V being supplied (1.1V -> VDDD). With the addition of the NOP it should get far enough into the program that you're able to to see some serial output. Additional fixes need to be added in order to complete the calibration code. The serial output is most likely at the wrong baud rate because calibration hasn't finished yet. Without the NOP, the "unsigned int position" variable being passed is set to zero. The position variable seems to be PUSHed onto the stack just fine but, when POPing, to restore it's value, it always sets it to zero. This can be better understood when looking at the assembly code.