### PR TITLE
1.1V fix

### DIFF
--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -246,9 +246,15 @@ void optical_sfd_isr(void) {
     }
 
     // Debugging output
-    printf("HF=%d-%d   2M=%d-%d,%d,%d   LC=%d-%d   IF=%d-%d\r\n", count_HFclock,
-           HF_CLOCK_fine, count_2M, RC2M_coarse, RC2M_fine, RC2M_superfine,
-           count_LC, optical_vars.LC_code, count_IF, IF_fine);
+    // 1.1V/VDDD tap fix
+    // The print is now broken down into 3 statements instead of one big
+    // print statement
+    // doing this prevent a long string of loads back to back
+    printf("HF=%d-%d   2M=%d-%d", count_HFclock, HF_CLOCK_fine, count_2M,
+           RC2M_coarse);
+    printf(",%d,%d   LC=%d-%d   ", RC2M_fine, RC2M_superfine, count_LC,
+           optical_vars.LC_code);
+    printf("IF=%d-%d\r\n", count_IF, IF_fine);
 
     if (optical_vars.optical_cal_iteration == 25) {
         // Disable this ISR

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -301,7 +301,7 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                     }
                     // 1.1V/VDDD tap fix
                     // adds extra delay
-                    // but, not compltely sure why this one is needed
+                    // but, not completely sure why this one is needed
                     __asm("NOP");
                     LC_FREQCHANGE(cfg_coarse, cfg_mid, cfg_fine);
 

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -250,12 +250,20 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_start = repeat_rx_tx_params.fixed_lc_mid;
         cfg_fine_start = repeat_rx_tx_params.fixed_lc_fine;
 
+        // 1.1V (NOP) VDDD tap fix
+        // the NOPs add some extra delay
+        // print statement also needed to be removed
+        // probably could be added back in if broken down into more
+        // than one print statement
         cfg_coarse_stop = cfg_coarse_start + 1;
+        __asm("NOP");
         cfg_mid_stop = cfg_mid_start + 1;
+        __asm("NOP");
         cfg_fine_stop = cfg_fine_start + 1;
+        __asm("NOP");
 
-        printf("Fixed %s at c:%u m:%u f:%u\n", radio_mode_string,
-               cfg_coarse_start, cfg_mid_start, cfg_fine_start);
+        // printf("Fixed %s at c:%u m:%u f:%u\n", radio_mode_string,
+        // cfg_coarse_start, cfg_mid_start, cfg_fine_start);
     } else {  // sweep mode
         cfg_coarse_start = repeat_rx_tx_params.sweep_lc_coarse_start;
         cfg_coarse_stop = repeat_rx_tx_params.sweep_lc_coarse_end;
@@ -291,7 +299,10 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                         printf("coarse=%d, middle=%d, fine=%d\r\n", cfg_coarse,
                                cfg_mid, cfg_fine);
                     }
-
+                    // 1.1V/VDDD tap fix
+                    // adds extra delay
+                    // but, not compltely sure why this one is needed
+                    __asm("NOP");
                     LC_FREQCHANGE(cfg_coarse, cfg_mid, cfg_fine);
 
                     if (repeat_rx_tx_params.radio_mode == RX_MODE) {

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1491,9 +1491,15 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     __asm("NOP");
 
     // flip the bit order to make it fit more easily into the ACFG registers
+    // 1.1V (NOP)
+    // The NOPs below are for the VDDD tap fix
+    // They provide some extra delay so the registers can be loaded properly
     unsigned int coarse_f = (unsigned int)(flipChar(coarse_m));
+    __asm("NOP");
     unsigned int mid_f = (unsigned int)(flipChar(mid_m));
+    __asm("NOP");
     unsigned int fine_f = (unsigned int)(flipChar(fine_m));
+    __asm("NOP");
 
     // initialize registers
     unsigned int fcode =


### PR DESCRIPTION
These changes fix the different modes in the frequency projects for the boards that need the VDDD tap fix. Before, the 1.1V fixes only worked for the tx sweep. Now it should work for the tx/rx sweep and fixed mode. The broken down print  statement in the optical.c file fixes the calibration output. Without the external 1.1V to VDDD the printed output had zeros for some of the variables it was trying to print. Calling any function with a lot of variables being passes is something that should be avoided when running the boards that need the 1.1V/VDDD tap fixes. This is because issues can pop up when there are a lot of loads back to back.