### PR TITLE
Add minor improvements to channel calibration

### DIFF
--- a/scm_v3c/applications/channel_cal/channel_cal_main.c
+++ b/scm_v3c/applications/channel_cal/channel_cal_main.c
@@ -10,16 +10,16 @@
 #include "scm3c_hw_interface.h"
 
 // Start coarse code for the sweep to find 802.15.4 channels.
-#define START_COARSE_CODE 24
+#define START_COARSE_CODE 23
 
 // End coarse code for the sweep to find 802.15.4 channels.
-#define END_COARSE_CODE 26
+#define END_COARSE_CODE 24
 
 int main(void) {
     initialize_mote();
 
     // Initialize the channel calibration.
-    printf("Initializing the channel calibration.\n");
+    printf("Initializing channel calibration.\n");
     if (!channel_cal_init(START_COARSE_CODE, END_COARSE_CODE)) {
         return EXIT_FAILURE;
     }
@@ -30,7 +30,7 @@ int main(void) {
     crc_check();
     perform_calibration();
 
-    printf("Running the channel calibration.\n");
+    printf("Running channel calibration.\n");
     if (!channel_cal_run()) {
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
This PR adds some minor improvements to the channel calibration code:
* When sending an acknowledgment packet to the OpenMote, SCuM will now include the channel that it is acknowledging.
* The TX and RX packet structs have been updated to reflect the presence of a CRC.
* SCuM will wait for a second between RX and TX calibration (this is because the OpenMote has an RX timeout of 500 ms).