### PR TITLE
Allow the sampling period to be configurable for a resistive sensor

### DIFF
--- a/scm_v3c/applications/sensor_adc/sensor_resistive.h
+++ b/scm_v3c/applications/sensor_adc/sensor_resistive.h
@@ -12,6 +12,9 @@ typedef struct {
     // RF timer ID.
     uint8_t rftimer_id;
 
+    // Sampling period in milliseconds.
+    uint16_t sampling_period_ms;
+
     // GPIO excitation pin.
     gpio_e gpio_excitation;
 


### PR DESCRIPTION
This PR allows the sampling period to be configurable for a resistive sensor.  This allows the measurable range of resistances (or capacitances for a capacitive sensor) to be adjusted on a per-sensor basis.